### PR TITLE
use the qualified name instead unary operator and indent code

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,7 @@
+# Used by "mix format"
+[
+  inputs: [
+    "mix.exs",
+    "{lib,test}/**/*.{ex,exs}"
+  ]
+]

--- a/lib/thread_first.ex
+++ b/lib/thread_first.ex
@@ -1,31 +1,29 @@
 defmodule ThreadFirstMacros do
-defmacro thread_first(args) do
+  defmacro thread_first(do: block) do
+    # get the statements' asts from the do block
+    [first_ast | rest_asts] =
+      block
+      |> case do
+        # if the do block has multiple statements it will be a __block__
+        # and the statements' asts will be its args
+        {:__block__, _, args} ->
+          args
 
-  # get the statements' asts from the do block
-  [first_ast | rest_asts] = args
-  # fetch the :do key
-  |> Keyword.fetch!(:do)
-  |> case do
+        # if only one statement in the do block the value of the :do:
+        # key will be the statement's ast
+        ast ->
+          [ast]
+      end
 
-       # if the do block has multiple statements it will be a __block__
-       # and the statements' asts will be its args
-       {:__block__, _, args} -> args
-
-       # if only one statement in the do block the value of the :do:
-       # key will be the statement's ast
-       ast -> [ast]
-           
-     end
-
-  # now use Macro.pipe to thread all the statements' asts together
-  # and return the threaded ast
-  rest_asts
-  |> Enum.reduce(first_ast,
-  fn rest_ast, this_ast ->
-    # insert this_ast as the 0th argument of rest_ast
-    Macro.pipe(this_ast, rest_ast, 0)
-  end)
-
-end
-
+    # now use Macro.pipe to thread all the statements' asts together
+    # and return the threaded ast
+    rest_asts
+    |> Enum.reduce(
+      first_ast,
+      fn rest_ast, this_ast ->
+        # insert this_ast as the 0th argument of rest_ast
+        Macro.pipe(this_ast, rest_ast, 0)
+      end
+    )
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,32 +1,41 @@
 defmodule ThreadFirst.Mixfile do
   use Mix.Project
+
   def project do
-    [app: :elixir_thread_first,
-     version: "0.0.1",
-     elixir: "~> 1.3",
-     description: description,
-      package: package,
-     #build_embedded: Mix.env == :prod,
-     #start_permanent: Mix.env == :prod,
-     deps: deps]
+    [
+      app: :elixir_thread_first,
+      version: "0.0.1",
+      elixir: "~> 1.3",
+      description: description(),
+      package: package(),
+      # build_embedded: Mix.env == :prod,
+      # start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
   end
+
   def application do
     [applications: [:logger]]
   end
+
   defp deps do
     []
   end
-  defp package do
-    [maintainers: ["Ian Rumford"],
-     files: ["lib", "mix.exs", "README*", "LICENSE*"],
-     licenses: ["MIT"],
-     links: %{github: "https://github.com/ianrumford/elixir-thread-first"}]
-  end
-  defp description do
-  """
-  elixir-thread-first: A thread-first macro for Elixir
 
-  An example of writing an Elixir macro to emulate Clojure's thread_first macro
-  """     
+  defp package do
+    [
+      maintainers: ["Ian Rumford"],
+      files: ["lib", "mix.exs", "README*", "LICENSE*"],
+      licenses: ["MIT"],
+      links: %{github: "https://github.com/ianrumford/elixir-thread-first"}
+    ]
+  end
+
+  defp description do
+    """
+    elixir-thread-first: A thread-first macro for Elixir
+
+    An example of writing an Elixir macro to emulate Clojure's thread_first macro
+    """
   end
 end

--- a/test/thread_first_test.exs
+++ b/test/thread_first_test.exs
@@ -1,40 +1,44 @@
 defmodule ThreadFirstTests do
-use ExUnit.Case
-require ThreadFirstMacros
-import ThreadFirstMacros
-test "thread1: HelloWorld" do
+  use ExUnit.Case
+  require ThreadFirstMacros
+  import ThreadFirstMacros
 
-  result = thread_first do
-    "hello world" 
-    String.split 
-    Stream.map(&String.capitalize/1) 
-    Enum.join
+  test "thread1: HelloWorld" do
+    result =
+      thread_first do
+        "hello world"
+        String.split()
+        Stream.map(&String.capitalize/1)
+        Enum.join()
+      end
+
+    assert result == "HelloWorld"
   end
 
-  assert result == "HelloWorld"
+  test "thread2: single-line do block" do
+    result =
+      thread_first do
+        "hello world"
+      end
 
-end
-test "thread2: single-line do block" do
-
-  result = thread_first do
-    "hello world" 
+    assert result == "hello world"
   end
 
-  assert result == "hello world" 
+  test "thread3: a calculator" do
+    result =
+      thread_first do
+        # piping into a unary operator is deprecated, please use the qualified name.
+        # For example, Kernel.+(5), instead of +5
 
-end
-test "thread3: a calculator" do
+        42
+        # 47
+        Kernel.+(5)
+        # 30
+        Kernel.-(17)
+        # remainder is 4
+        rem(26)
+      end
 
-  result = thread_first do
-
-    42
-    + 5 # 47
-    - 17 # 30
-    rem 26 # remainder is 4 
-    
+    assert 4 == result
   end
-  
-  assert 4 == result 
-  
-end
 end


### PR DESCRIPTION
piping into a unary operator is deprecated, use the qualified name instead.
indent code.